### PR TITLE
Bump to imglib2 6.x API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 		<developer>
 			<id>maarzt</id>
 			<name>Matthias Arzt</name>
-			<url>https://imagej.net/people/Maarzt</url>
+			<url>https://imagej.net/people/maarzt</url>
 			<roles>
 				<role>founder</role>
 				<role>lead</role>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,17 @@
 
 		<fastRandomForest.version>r49</fastRandomForest.version>
 		<imagescience.version>3.0.0</imagescience.version>
+
+		<bigdataviewer-core.version>10.4.6</bigdataviewer-core.version>
+		<imagej-deprecated.version>0.2.0</imagej-deprecated.version>
+		<imagej-ops.version>2.0.0</imagej-ops.version>
+		<imglib2.version>6.1.0</imglib2.version>
+		<imglib2-algorithm.version>0.13.2</imglib2-algorithm.version>
+		<imglib2-algorithm-gpl.version>0.3.1</imglib2-algorithm-gpl.version>
+		<imglib2-cache.version>1.0.0-beta-17</imglib2-cache.version>
+		<imglib2-realtransform.version>4.0.1</imglib2-realtransform.version>
+		<imglib2-roi.version>0.14.0</imglib2-roi.version>
+		<scifio.version>0.45.0</scifio.version>
 	</properties>
 
 	<repositories>

--- a/src/main/java/sc/fiji/labkit/pixel_classification/utils/views/CompositeRandomAccess.java
+++ b/src/main/java/sc/fiji/labkit/pixel_classification/utils/views/CompositeRandomAccess.java
@@ -55,18 +55,13 @@ public class CompositeRandomAccess<T> implements RandomAccess<Composite<T>>, Com
 	}
 
 	@Override
-	public RandomAccess<Composite<T>> copyRandomAccess() {
-		return new CompositeRandomAccess<>(ra.copyRandomAccess());
+	public RandomAccess<Composite<T>> copy() {
+		return new CompositeRandomAccess<>(ra.copy());
 	}
 
 	@Override
 	public Composite<T> get() {
 		return this;
-	}
-
-	@Override
-	public Sampler<Composite<T>> copy() {
-		return copyRandomAccess();
 	}
 
 	@Override


### PR DESCRIPTION
This work updates the POM to depend on imglib2-6.x-based component versions, and makes the necessary changes to the code to account for the associated API breakages.

It would be nice to merge and release this work ASAP as a new version of labkit-pixel-classification, so that we can get it into pom-scijava 35 (and also hopefully start bundling Labkit with Fiji, finally!).
